### PR TITLE
Bump version to 1.20.4

### DIFF
--- a/prosopo-procaptcha/prosopo-procaptcha.php
+++ b/prosopo-procaptcha/prosopo-procaptcha.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Prosopo Procaptcha
  * Description: GDPR compliant, privacy friendly and better value captcha.
- * Version: 1.20.3
+ * Version: 1.20.4
  * Author: Prosopo Team
  * Author URI: https://prosopo.io/
  * License: GPLv2 or later

--- a/prosopo-procaptcha/readme.txt
+++ b/prosopo-procaptcha/readme.txt
@@ -4,7 +4,7 @@ Tags: Captcha, Procaptcha, antispam, anibot, spam.
 Requires at least: 5.5
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 1.20.3
+Stable tag: 1.20.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -134,6 +134,9 @@ Please start a thread in the [support forum](https://wordpress.org/support/plugi
 Absolutely! The plugin has a [public GitHub repository](https://github.com/prosopo/procaptcha-wordpress-plugin), and we would be excited to have your contribution 🤝
 
 == Changelog ==
+
+= 1.20.4 (2026-08-10) =
+* Fix: fatal error on load when using Gravity Forms 3.0.2+ (get_field_label signature mismatch)
 
 = 1.20.3 (2026-01-20) =
 * Maintenance: compatibility with the latest Procaptcha statistics API


### PR DESCRIPTION
## Summary
- Bumps `Version:` header in `prosopo-procaptcha.php` and `Stable tag:` in `readme.txt` to `1.20.4`.
- Adds changelog entry for the Gravity Forms 3.0.2 fatal-error fix landed in #49.

## Test plan
- [x] `Version:` and `Stable tag:` match.
- [x] Changelog entry follows existing style.
- [ ] Manual smoke test recommended before cutting the release tag: PoW / Frictionless / Image captcha on WP + Gravity Forms 3.0.2.

Next steps after merging this:
1. Open `main` → `release` PR.
2. After merge, tag `1.20.4` on `release` to trigger the SVN deploy via `.github/workflows/release-new-version.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)